### PR TITLE
#23 Adds basic docker-compose file to set up Redis locally inside a container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:latest
+    container_name: delivery-redis-instance
+
+    ports:
+      - "6379:6379"
+
+    volumes:
+      - redis_data:/data
+
+    restart: always
+    
+volumes:
+    redis_data:


### PR DESCRIPTION
Tilføjer en standard docker-compose.yml, som kan bruges til at starte en Redis instans. Kan sættes i gang med docker-compose up -d inde i root af projektet. Det er ikke testet, om applikationen overhovedet kan få adgang til porten den kører på, men jeg har håb. 🙏 